### PR TITLE
urkel: fix inspect for node >=10

### DIFF
--- a/lib/optimized/nodes.js
+++ b/lib/optimized/nodes.js
@@ -10,6 +10,7 @@
 
 const assert = require('bsert');
 const common = require('./common');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 const {AssertionError} = require('./errors');
 
 const {
@@ -149,7 +150,7 @@ class Null extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return '<NIL>';
   }
 }
@@ -246,7 +247,7 @@ class Internal extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return {
       left: this.left,
       right: this.right
@@ -335,7 +336,7 @@ class Leaf extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Leaf: ${this.key.toString('hex')}>`;
   }
 
@@ -379,7 +380,7 @@ class Hash extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Hash: ${this.data.toString('hex')}>`;
   }
 }

--- a/lib/radix/nodes.js
+++ b/lib/radix/nodes.js
@@ -11,6 +11,7 @@
 const assert = require('bsert');
 const Bits = require('./bits');
 const common = require('./common');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 const {AssertionError} = require('./errors');
 
 const {
@@ -127,7 +128,7 @@ class Pointer {
     return this.read(data, 0);
   }
 
-  inspect() {
+  [inspect]() {
     return {
       index: this.index,
       pos: this.pos,
@@ -245,7 +246,7 @@ class Null extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return '<NIL>';
   }
 }
@@ -418,7 +419,7 @@ class Internal extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return {
       prefix: this.prefix.toString(),
       left: this.left,
@@ -503,7 +504,7 @@ class Leaf extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Leaf: ${this.key.toString('hex')}>`;
   }
 
@@ -540,7 +541,7 @@ class Hash extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Hash: ${this.data.toString('hex')}>`;
   }
 }

--- a/lib/radix/proof.js
+++ b/lib/radix/proof.js
@@ -10,6 +10,7 @@ const assert = require('bsert');
 const Bits = require('./bits');
 const common = require('./common');
 const errors = require('./errors');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const {
   EMPTY,
@@ -711,7 +712,7 @@ class ProofNode {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     const prefix = this.prefix.toString();
     const node = this.node.toString('hex');
 

--- a/lib/trie/nodes.js
+++ b/lib/trie/nodes.js
@@ -11,6 +11,7 @@
 const assert = require('bsert');
 const Bits = require('./bits');
 const common = require('./common');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 const {AssertionError} = require('./errors');
 
 const {
@@ -127,7 +128,7 @@ class Pointer {
     return this.read(data, 0);
   }
 
-  inspect() {
+  [inspect]() {
     return {
       index: this.index,
       pos: this.pos,
@@ -245,7 +246,7 @@ class Null extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return '<NIL>';
   }
 }
@@ -383,7 +384,7 @@ class Internal extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return {
       left: this.left,
       right: this.right
@@ -467,7 +468,7 @@ class Leaf extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Leaf: ${this.key.toString('hex')}>`;
   }
 
@@ -504,7 +505,7 @@ class Hash extends Node {
     return this;
   }
 
-  inspect() {
+  [inspect]() {
     return `<Hash: ${this.data.toString('hex')}>`;
   }
 }


### PR DESCRIPTION
The use of `inspect()` as a method in classes is now deprecated as per [[DEP0079]](https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect).

A symbol should be used <11.0.0 and >10.0.0, or you'll get a warning.
If you use a node version >11.0.0, the inspect method won't be picked up at all when logging.

---

* Old inspect method not removed due to:
  > For backward compatibility with Node.js prior to version 6.4.0, both may be specified
* `Symbol` has support for back to [0.12.18](https://node.green/#ES2015-built-ins-Symbol).
* `util.inspect.custom` was added in [6.6.0](https://nodejs.org/api/util.html#util_util_inspect_custom).