### PR TITLE
radix/store: update lastMeta every commit

### DIFF
--- a/lib/radix/store.js
+++ b/lib/radix/store.js
@@ -577,6 +577,7 @@ class Store {
     await this.flush();
     await this.sync();
 
+    this.lastMeta = this.state;
     this.state = state;
 
     if (!node.isNull()) {

--- a/test/recovery-test.js
+++ b/test/recovery-test.js
@@ -1,0 +1,97 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint no-unused-vars: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const crypto = require('crypto');
+const {tmpdir} = require('os');
+const path = require('path');
+const fs = require('bfile');
+const {Tree, Proof} = require('../radix');
+const {sha1, sha256} = require('./util/util');
+
+function key(bits) {
+  return Buffer.from([bits]);
+}
+
+const FOO1 = key(0b00000000);
+const FOO2 = key(0b10000000);
+const FOO3 = key(0b11000000);
+const FOO4 = key(0b10100000);
+
+const BAR1 = Buffer.from([1]);
+const BAR2 = Buffer.from([2]);
+const BAR3 = Buffer.from([3]);
+const BAR4 = Buffer.from([4]);
+
+describe('Recovery Test', function() {
+  let tree;
+  let txn;
+  let root1, root2;
+
+  const location = path.join(tmpdir(), `urkel-recovery-test-${Date.now()}`);
+
+  after(() => {
+    fs.rimraf(location);
+  });
+
+  for (const dir of [location, null]) {
+    describe(`${dir ? 'Disk': 'Memory'}`, function() {
+      it('should init tree', async () => {
+        tree = new Tree(sha256, 8, dir);
+        await tree.open();
+        txn = tree.transaction();
+      });
+
+      it('should add 3 records', async () => {
+        await txn.insert(FOO1, BAR1);
+        await txn.insert(FOO2, BAR2);
+        await txn.insert(FOO3, BAR3);
+      });
+
+      it('should commit with 3 records and save root', async () => {
+        root1 = await txn.commit();
+      });
+
+      it('should add one record after commit', async () => {
+        await txn.insert(FOO4, BAR4);
+      });
+
+      it('should commit with 4 records and save root', async () => {
+        root2 = await txn.commit();
+      });
+
+      it('should clear tree store rootCache', async () => {
+        // Normally only happens on tree.store.close();
+        tree.store.rootCache.clear();
+      });
+
+      it('should restore tree from first saved root', async () => {
+        await tree.inject(root1);
+        txn = tree.transaction();
+      });
+
+      it('should only get 3 records after restoring from first root', async () => {
+        assert.bufferEqual(await txn.get(FOO1), BAR1);
+        assert.bufferEqual(await txn.get(FOO2), BAR2);
+        assert.bufferEqual(await txn.get(FOO3), BAR3);
+
+        assert.strictEqual(await txn.get(FOO4), null);
+      });
+
+      it('should restore tree from second saved root', async () => {
+        await tree.inject(root2);
+        txn = tree.transaction();
+      });
+
+      it('should get all records after restoring from second root', async () => {
+        assert.bufferEqual(await txn.get(FOO1), BAR1);
+        assert.bufferEqual(await txn.get(FOO2), BAR2);
+        assert.bufferEqual(await txn.get(FOO3), BAR3);
+        assert.bufferEqual(await txn.get(FOO4), BAR4);
+      });
+    });
+  }
+});


### PR DESCRIPTION
I'm going down the rabbit hole on Urkel Tree state recovery (ie. a HNS reorg over a tree interval) and I noticed we have these caches for previously seen tree roots:

`getHistory()`

https://github.com/handshake-org/urkel/blob/547ab1e6213addd1168ae8b442e57e999369392a/lib/radix/store.js#L762-L765

`_readHistory()`

https://github.com/handshake-org/urkel/blob/547ab1e6213addd1168ae8b442e57e999369392a/lib/radix/store.js#L786-L789

I disabled them out of curiosity because I wanted to see Urkel to follow the Meta pointers saved to disk. However, without the cache injecting old roots totally fails.

Currently, Urkel loads the last state from disk and then assumes all new committed tree roots are saved in this cache. I don't think there's any reason to assume the cache will ever be prematurely cleared, but as a reviewer it might seem like a cache is just an optimization and not actually a requirement. The test I added covers an edge case where a developer may inadvertently clear the root cache from the Urkel store. If that happens, old roots can still be injected by following the chain of Meta pointers since this patch updates the `store.lastMeta` on every commit.


