### PR TITLE
Recover cache on open.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Only the `radix` variant is currently maintained by The Handshake Developers.
 
 ## Usage
 
-``` js
+```javascript
 const bcrypto = require('bcrypto');
 const urkel = require('urkel');
 const {BLAKE2b, randomBytes} = bcrypto;
@@ -74,7 +74,11 @@ const {Tree, Proof} = urkel;
 
 // Create a tree using blake2b-256
 // and a depth/key-size of 256 bits.
-const tree = new Tree(BLAKE2b, 256, '/path/to/my/db');
+const tree = new Tree({
+  hash: BLAKE2b,
+  bits: 256,
+  prefix: '/path/to/my/db'
+});
 
 await tree.open();
 

--- a/bench/tree.js
+++ b/bench/tree.js
@@ -24,7 +24,11 @@ function verify(root, key, proof) {
 }
 
 async function stress(prefix) {
-  const tree = new Tree(blake2b, 256, prefix);
+  const tree = new Tree({
+    hash: blake2b,
+    bits: 256,
+    prefix
+  });
   const store = tree.store;
 
   await tree.open();
@@ -147,7 +151,11 @@ async function doProof(tree, i, key, expect) {
 }
 
 async function bench(prefix) {
-  const tree = new Tree(blake2b, 256, prefix);
+  const tree = new Tree({
+    hash: blake2b,
+    bits: 256,
+    prefix
+  });
   const items = [];
 
   await tree.open();

--- a/lib/store.js
+++ b/lib/store.js
@@ -65,19 +65,16 @@ const ZERO_KEY = Buffer.alloc(KEY_SIZE, 0x00);
  */
 
 class Store {
-  constructor(fs, prefix, hash, bits) {
+  constructor(fs, options) {
     assert(fs && typeof fs.write === 'function');
-    assert(typeof prefix === 'string');
-    assert(hash && typeof hash.digest === 'function');
-    assert((bits >>> 0) === bits);
-    assert(bits > 0 && (bits & 7) === 0);
 
     this.fs = fs;
-    this.prefix = prefix;
-    this.hash = hash;
-    this.bits = bits;
+    this.options = new StoreOptions(options);
+    this.prefix = this.options.prefix;
+    this.hash = this.options.hash;
+    this.bits = this.options.bits;
 
-    this.lockFile = new LockFile(fs, prefix);
+    this.lockFile = new LockFile(fs, this.prefix);
     this.openLock = new MapLock();
     this.readLock = new Lock();
     this.buffer = new WriteBuffer();
@@ -92,7 +89,7 @@ class Store {
 
   clone(prefix) {
     const {hash, bits} = this;
-    return new this.constructor(prefix, hash, bits);
+    return new this.constructor({prefix, hash, bits});
   }
 
   path(index) {
@@ -834,6 +831,28 @@ class Store {
   }
 }
 
+class StoreOptions {
+  constructor(options) {
+    this.hash = null;
+    this.bits = null;
+    this.prefix = null;
+
+    this.fromOptions(options);
+  }
+
+  fromOptions(options) {
+    assert(options);
+    assert(options.hash && typeof options.hash.digest === 'function');
+    assert((options.bits >>> 0) === options.bits);
+    assert(options.bits > 0 && (options.bits & 7) === 0);
+    assert(typeof options.prefix === 'string');
+
+    this.prefix = options.prefix;
+    this.hash = options.hash;
+    this.bits = options.bits;
+  }
+}
+
 /**
  * Meta
  */
@@ -1130,8 +1149,8 @@ class FileMap {
  */
 
 class FileStore extends Store {
-  constructor(prefix, hash, bits) {
-    super(fs, prefix, hash, bits);
+  constructor(options) {
+    super(fs, options);
   }
 }
 
@@ -1140,8 +1159,8 @@ class FileStore extends Store {
  */
 
 class MemoryStore extends Store {
-  constructor(prefix, hash, bits) {
-    super(new MFS(), prefix, hash, bits);
+  constructor(options) {
+    super(new MFS(), options);
   }
 }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -199,9 +199,9 @@ class Store {
       throw new Error('Store already opened.');
 
     const index = await this.ensure();
-    const [state, meta] = await this.recoverState(index);
-
     await this.lockFile.open();
+
+    const [state, meta] = await this.recoverState(index);
 
     this.state = state;
     this.index = state.metaPtr.index || 1;

--- a/lib/store.js
+++ b/lib/store.js
@@ -83,7 +83,7 @@ class Store {
     this.state = new Meta();
     this.index = 0;
     this.lastMeta = new Meta();
-    // tracks root cache indexer pointer.
+    // tracks root cache pointer.
     this.lastCachedMeta = new Meta();
     this.rootCache = new Map();
     this.key = ZERO_KEY;
@@ -742,12 +742,12 @@ class Store {
     }
   }
 
-  resetIndexer() {
+  resetLastCachedMeta() {
     this.lastCachedMeta = this.lastMeta;
   }
 
   resetCache() {
-    this.resetIndexer();
+    this.resetLastCachedMeta();
     this.rootCache.clear();
   }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -82,8 +82,10 @@ class Store {
     this.current = null;
     this.state = new Meta();
     this.index = 0;
-    this.rootCache = new Map();
     this.lastMeta = new Meta();
+    // tracks root cache indexer pointer.
+    this.indexMeta = new Meta();
+    this.rootCache = new Map();
     this.key = ZERO_KEY;
   }
 
@@ -203,9 +205,13 @@ class Store {
     this.state = state;
     this.index = state.metaPtr.index || 1;
     this.lastMeta = meta;
+    this.indexMeta = meta;
     this.current = await this.openFile(this.index, 'a+');
     this.start();
     this.state.rootNode = await this.getRoot();
+
+    if (this.options.initCacheSize !== 0)
+      await this.recoverCache(this.options.initCacheSize);
 
     return this.state.rootNode;
   }
@@ -228,6 +234,7 @@ class Store {
     this.index = 0;
     this.rootCache.clear();
     this.lastMeta = new Meta();
+    this.indexMeta = new Meta();
     this.key = ZERO_KEY;
 
     for (const file of files.values())
@@ -700,6 +707,48 @@ class Store {
     return [new Meta(), new Meta()];
   }
 
+  async recoverCache(rootsCount) {
+    const unlock = await this.readLock.lock();
+
+    try {
+      return await this._recoverCache(rootsCount);
+    } finally {
+      unlock();
+    }
+  }
+
+  async _recoverCache(rootsCount) {
+    assert(typeof rootsCount === 'number');
+
+    let {metaPtr} = this.indexMeta;
+
+    if (rootsCount === -1)
+      rootsCount = Number.MAX_VALUE;
+
+    for (let i = rootsCount; i > 0; i--) {
+      if (metaPtr.index === 0)
+        return;
+
+      const meta = await this.readMeta(metaPtr);
+      const {rootPtr} = meta;
+
+      // this will cache the root.
+      await this.readRoot(rootPtr);
+
+      this.indexMeta = meta;
+      metaPtr = meta.metaPtr;
+    }
+  }
+
+  resetIndexer() {
+    this.indexMeta = this.lastMeta;
+  }
+
+  resetCache() {
+    this.resetIndexer();
+    this.rootCache.clear();
+  }
+
   async readMeta(ptr) {
     const data = await this.read(ptr.index, ptr.pos, META_SIZE);
     return Meta.decode(data, this.hash, this.key);
@@ -786,7 +835,14 @@ class Store {
     if (cached)
       return cached;
 
-    let {metaPtr} = this.lastMeta;
+    if (this.options.cacheOnly) {
+      throw new MissingNodeError({
+        rootHash: rootHash,
+        nodeHash: rootHash
+      });
+    }
+
+    let {metaPtr} = this.indexMeta;
 
     for (;;) {
       if (metaPtr.index === 0) {
@@ -801,7 +857,7 @@ class Store {
       const node = await this.readRoot(rootPtr);
       const hash = node.hash(this.hash);
 
-      this.lastMeta = meta;
+      this.indexMeta = meta;
 
       if (hash.equals(rootHash))
         return node;
@@ -836,6 +892,8 @@ class StoreOptions {
     this.hash = null;
     this.bits = null;
     this.prefix = null;
+    this.cacheOnly = false;
+    this.initCacheSize = 0;
 
     this.fromOptions(options);
   }
@@ -850,6 +908,19 @@ class StoreOptions {
     this.prefix = options.prefix;
     this.hash = options.hash;
     this.bits = options.bits;
+
+    if (options.cacheOnly != null) {
+      assert(typeof options.cacheOnly === 'boolean');
+      this.cacheOnly = options.cacheOnly;
+    }
+
+    if (options.initCacheSize != null) {
+      assert(typeof options.initCacheSize === 'number');
+      assert(options.initCacheSize >= -1);
+      this.initCacheSize = options.initCacheSize;
+    }
+
+    return this;
   }
 }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -84,14 +84,16 @@ class Store {
     this.index = 0;
     this.lastMeta = new Meta();
     // tracks root cache indexer pointer.
-    this.indexMeta = new Meta();
+    this.lastCachedMeta = new Meta();
     this.rootCache = new Map();
     this.key = ZERO_KEY;
   }
 
   clone(prefix) {
-    const {hash, bits} = this;
-    return new this.constructor({prefix, hash, bits});
+    return new this.constructor({
+      ...this.options,
+      prefix
+    });
   }
 
   path(index) {
@@ -205,7 +207,7 @@ class Store {
     this.state = state;
     this.index = state.metaPtr.index || 1;
     this.lastMeta = meta;
-    this.indexMeta = meta;
+    this.lastCachedMeta = meta;
     this.current = await this.openFile(this.index, 'a+');
     this.start();
     this.state.rootNode = await this.getRoot();
@@ -234,7 +236,7 @@ class Store {
     this.index = 0;
     this.rootCache.clear();
     this.lastMeta = new Meta();
-    this.indexMeta = new Meta();
+    this.lastCachedMeta = new Meta();
     this.key = ZERO_KEY;
 
     for (const file of files.values())
@@ -720,7 +722,7 @@ class Store {
   async _recoverCache(rootsCount) {
     assert(typeof rootsCount === 'number');
 
-    let {metaPtr} = this.indexMeta;
+    let {metaPtr} = this.lastCachedMeta;
 
     if (rootsCount === -1)
       rootsCount = Number.MAX_VALUE;
@@ -735,13 +737,13 @@ class Store {
       // this will cache the root.
       await this.readRoot(rootPtr);
 
-      this.indexMeta = meta;
+      this.lastCachedMeta = meta;
       metaPtr = meta.metaPtr;
     }
   }
 
   resetIndexer() {
-    this.indexMeta = this.lastMeta;
+    this.lastCachedMeta = this.lastMeta;
   }
 
   resetCache() {
@@ -842,7 +844,7 @@ class Store {
       });
     }
 
-    let {metaPtr} = this.indexMeta;
+    let {metaPtr} = this.lastCachedMeta;
 
     for (;;) {
       if (metaPtr.index === 0) {
@@ -857,7 +859,7 @@ class Store {
       const node = await this.readRoot(rootPtr);
       const hash = node.hash(this.hash);
 
-      this.indexMeta = meta;
+      this.lastCachedMeta = meta;
 
       if (hash.equals(rootHash))
         return node;

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -584,7 +584,7 @@ class TreeOptions {
     assert(options.hash && typeof options.hash.digest === 'function',
       'Tree requires proper hash with digest.');
     assert((options.bits >>> 0) === options.bits,
-      'options.bits must be a 32 bit integer.');
+      'Bits must be a 32 bit integer.');
     assert(options.bits > 0 && (options.bits & 7) === 0);
 
     this.hash = options.hash;

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -54,28 +54,18 @@ class Tree {
   /**
    * Create a tree.
    * @constructor
-   * @param {Object} hash
-   * @param {Number} bits
-   * @param {String} prefix
+   * @param {Object} options
+   * @param {Object} options.hash
+   * @param {Number} options.bits
+   * @param {String} options.prefix
    */
 
-  constructor(hash, bits, prefix) {
-    assert(hash && typeof hash.digest === 'function');
-    assert((bits >>> 0) === bits);
-    assert(bits > 0 && (bits & 7) === 0);
-    assert(!prefix || typeof prefix === 'string');
-
-    let Store = FileStore;
-
-    if (!prefix) {
-      Store = MemoryStore;
-      prefix = '/store';
-    }
-
-    this.hash = hash;
-    this.bits = bits;
-    this.prefix = prefix || null;
-    this.store = new Store(prefix, hash, bits);
+  constructor(options) {
+    this.options = new TreeOptions(options);
+    this.hash = this.options.hash;
+    this.bits = this.options.bits;
+    this.prefix = this.options.prefix;;
+    this.store = new this.options.Store(this.options);
     this.root = NIL;
   }
 
@@ -555,6 +545,51 @@ outer:
 
   txn() {
     return this.transaction();
+  }
+}
+
+class TreeOptions {
+  /**
+   * Create TreeOptions
+   * @param {Object} options
+   */
+
+  constructor(options) {
+    this.hash = null;
+    this.bits = null;
+    this.Store = MemoryStore;
+    this.prefix = '/store';
+    this.memory = true;
+
+    this.fromOptions(options);
+  }
+
+  /**
+   * Init options.
+   * @param {Object} options
+   * @returns {TreeOptions}
+   */
+
+  fromOptions(options) {
+    assert(options, 'Tree requires options.');
+    assert(options.hash && typeof options.hash.digest === 'function',
+      'Tree requires proper hash with digest.');
+    assert((options.bits >>> 0) === options.bits,
+      'options.bits must be a 32 bit integer.');
+    assert(options.bits > 0 && (options.bits & 7) === 0);
+
+    this.hash = options.hash;
+    this.bits = options.bits;
+
+    if (options.prefix != null) {
+      assert(typeof options.prefix === 'string',
+        'options.prefix must be a string');
+      this.Store = FileStore;
+      this.prefix = options.prefix;
+      this.memory = false;
+    }
+
+    return this;
   }
 }
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -58,6 +58,12 @@ class Tree {
    * @param {Object} options.hash
    * @param {Number} options.bits
    * @param {String} options.prefix
+   * @param {Boolean} options.cacheOnly - Only read disk on open.
+   *                                      Depend on the inititial root cache.
+   * @param {Number} options.initCacheSize - How many root hashes to index on
+   *                                         open.
+   *                                          - `-1` means all.
+   *                                          - `0` means disabled.
    */
 
   constructor(options) {
@@ -561,6 +567,9 @@ class TreeOptions {
     this.prefix = '/store';
     this.memory = true;
 
+    this.cacheOnly = false;
+    this.initCacheSize = 0;
+
     this.fromOptions(options);
   }
 
@@ -587,6 +596,17 @@ class TreeOptions {
       this.Store = FileStore;
       this.prefix = options.prefix;
       this.memory = false;
+    }
+
+    if (options.cacheOnly != null) {
+      assert(typeof options.cacheOnly === 'boolean');
+      this.cacheOnly = options.cacheOnly;
+    }
+
+    if (options.initCacheSize != null) {
+      assert(typeof options.initCacheSize === 'number');
+      assert(options.initCacheSize >= -1);
+      this.initCacheSize = options.initCacheSize;
     }
 
     return this;

--- a/test/recovery-test.js
+++ b/test/recovery-test.js
@@ -64,7 +64,7 @@ describe('Recovery Test', function() {
 
       it('should clear tree store rootCache', async () => {
         // Just do manual cache reset
-        // clears cache and reset indexer ptr.
+        // clears cache and resets cache ptr.
         tree.store.resetCache();
       });
 

--- a/test/recovery-test.js
+++ b/test/recovery-test.js
@@ -35,7 +35,11 @@ describe('Recovery Test', function() {
   for (const dir of [location, null]) {
     describe(`${dir ? 'Disk': 'Memory'}`, function() {
       it('should init tree', async () => {
-        tree = new Tree(sha256, 8, dir);
+        tree = new Tree({
+          hash: sha256,
+          bits: 8,
+          prefix: dir
+        });
         await tree.open();
         txn = tree.transaction();
       });

--- a/test/recovery-test.js
+++ b/test/recovery-test.js
@@ -63,8 +63,9 @@ describe('Recovery Test', function() {
       });
 
       it('should clear tree store rootCache', async () => {
-        // Normally only happens on tree.store.close();
-        tree.store.rootCache.clear();
+        // Just do manual cache reset
+        // clears cache and reset indexer ptr.
+        tree.store.resetCache();
       });
 
       it('should restore tree from first saved root', async () => {

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -1,0 +1,359 @@
+'use strict';
+
+const assert = require('bsert');
+const {tmpdir} = require('os');
+const path = require('path');
+const fs = require('bfile');
+const {sha256} = require('./util/util');
+const {Tree} = require('../lib/urkel');
+
+let keyCounter = 0;
+
+function getNextKey(bits) {
+  assert(bits >= 32);
+  const buffer = Buffer.alloc(bits / 8);
+  buffer.writeUint32BE(keyCounter);
+  keyCounter++;
+  return buffer;
+}
+
+async function addEntries(txn, n, bits) {
+  for (let i = 0; i < n; i++) {
+    const key = getNextKey(bits);
+    const value = Buffer.alloc(bits / 8);
+    key.copy(value);
+    await txn.insert(key, value);
+  }
+
+  return txn;
+}
+
+async function populateTree(tree, roots, perCommit) {
+  const hashes = new Set();
+
+  for (let i = 0; i < roots; i++) {
+    const txn = tree.transaction();
+
+    await addEntries(txn, perCommit, tree.bits);
+
+    const hash = await txn.commit();
+    hashes.add(hash.toString('binary'));
+  }
+
+  return hashes;
+}
+
+function mapHasSet(map, set) {
+  if (map.size !== set.size)
+    return false;
+
+  for (const key of set.values()) {
+    if (!map.has(key))
+      return false;
+  }
+
+  return true;
+}
+
+describe('Store', function() {
+  const treeOptions = {
+    hash: sha256,
+    bits: 160
+  };
+
+  for (const memory of [true, false]) {
+    describe(`Cache ${memory ? 'Memory' : 'Disk'}`, function() {
+      let options = null;
+      let prefix = null;
+
+      beforeEach(async () => {
+        if (!memory)
+          prefix = path.join(tmpdir(), `urkel-cache-test-${Date.now()}`);
+
+        options = {
+          ...treeOptions,
+          prefix
+        };
+      });
+
+      afterEach(async () => {
+        if (!memory) {
+          await fs.rimraf(prefix);
+          prefix = null;
+        }
+
+        options = null;
+      });
+
+      it('should cache root hashes when added', async () => {
+        const tree = new Tree(options);
+
+        await tree.open();
+
+        const {rootCache} = tree.store;
+        assert.strictEqual(rootCache.size, 0);
+
+        let roots = await populateTree(tree, 1, 2);
+        assert.strictEqual(rootCache.size, 1);
+        assert(mapHasSet(rootCache, roots));
+
+        roots = new Set([...roots, ...await populateTree(tree, 1, 2)]);
+        assert.strictEqual(rootCache.size, 2);
+        assert(mapHasSet(rootCache, roots));
+
+        await tree.close();
+      });
+
+      it('should not recover hashes when initCacheSize is 0', async () => {
+        const opts = {
+          ...options,
+          initCacheSize: 0
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        let roots;
+
+        // prepare tree
+        await tree.open();
+        roots = await populateTree(tree, 10, 2);
+        assert.strictEqual(rootCache.size, 10);
+        assert.strictEqual(rootCache.size, roots.size);
+        assert(mapHasSet(rootCache, roots));
+        await tree.close();
+
+        // test
+        await tree.open();
+        // last meta root itself is getting cached.
+        assert.strictEqual(rootCache.size, 1);
+
+        const {lastMeta, indexMeta} = tree.store;
+
+        // cache one more thing.
+        roots = new Set([
+          tree.root.hash().toString('binary'),
+          ...await populateTree(tree, 1, 2)
+        ]);
+
+        assert.strictEqual(rootCache.size, 2);
+        assert.strictEqual(rootCache.size, roots.size);
+        assert(mapHasSet(rootCache, roots));
+
+        // indexMeta does not go forward
+        assert.strictEqual(indexMeta, tree.store.indexMeta);
+        assert.notStrictEqual(lastMeta, tree.store.lastMeta);
+
+        await tree.close();
+      });
+
+      it('should recover all hashes when initCacheSize is -1', async () => {
+        const opts = {
+          ...options,
+          initCacheSize: -1
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        await tree.open();
+        const roots = await populateTree(tree, 10, 2);
+        assert.strictEqual(rootCache.size, 10);
+        assert(mapHasSet(rootCache, roots));
+        await tree.close();
+
+        await tree.open();
+        assert.strictEqual(rootCache.size, 10);
+        assert(mapHasSet(rootCache, roots));
+        await tree.close();
+      });
+
+      it('should recover initCacheSize roots in the cache', async () => {
+        const initCacheSize = 2;
+        // on open we index first root.
+        const initialRootCount = initCacheSize + 1;
+
+        const opts = {
+          ...options,
+          initCacheSize
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        await tree.open();
+        const roots = await populateTree(tree, 10, 2);
+        assert.strictEqual(rootCache.size, 10);
+        assert(mapHasSet(rootCache, roots));
+        await tree.close();
+
+        await tree.open();
+        assert.strictEqual(rootCache.size, initialRootCount);
+        const lastThree = new Set([...roots].slice(-initialRootCount));
+        assert(mapHasSet(rootCache, lastThree));
+
+        // make sure indexMeta is correctly set to the last indexed root.
+        const last = [...rootCache.values()][initialRootCount - 1].hash();
+        const checkRoot = await tree.store.readRoot(tree.store.indexMeta.rootPtr);
+        assert.bufferEqual(last, checkRoot.hash());
+
+        await tree.close();
+      });
+
+      it('should not lookup disk (cacheOnly)', async () => {
+        const opts = {
+          ...options,
+          cacheOnly: true
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        let rootHashes = [];
+
+        await tree.open();
+        const roots = await populateTree(tree, 10, 2);
+        assert.strictEqual(rootCache.size, 10);
+        assert(mapHasSet(rootCache, roots));
+
+        rootHashes = [...rootCache.values()].map(n => n.hash(tree.hash));
+        await tree.close();
+
+        await tree.open();
+        const {lastMeta, indexMeta} = tree.store;
+        assert.strictEqual(rootCache.size, 1);
+
+        const checkTreeRoots = [];
+        for (const hash of rootHashes.reverse()) {
+          const snap = tree.snapshot(hash);
+
+          try {
+            const root = await snap.getRoot();
+            checkTreeRoots.push(root);
+          } catch (e) {
+            checkTreeRoots.push(null);
+          }
+        }
+
+        assert.notStrictEqual(checkTreeRoots[0], null);
+        for (let i = 1; i < checkTreeRoots.length; i++)
+          assert.strictEqual(checkTreeRoots[i], null);
+
+        // neither lastMeta nor indexMeta should change.
+        assert.strictEqual(lastMeta, tree.store.lastMeta);
+        assert.strictEqual(indexMeta, tree.store.indexMeta);
+
+        await tree.close();
+      });
+
+      it('should only lookup initial cached roots (cacheOnly)', async () => {
+        const initCacheSize = 2;
+        const initialRootCount = initCacheSize + 1;
+
+        const opts = {
+          ...options,
+          initCacheSize,
+          cacheOnly: true
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        let rootHashes = [];
+
+        await tree.open();
+        const roots = await populateTree(tree, 10, 2);
+        assert.strictEqual(rootCache.size, 10);
+        assert(mapHasSet(rootCache, roots));
+
+        rootHashes = [...rootCache.values()].map(n => n.hash(tree.hash));
+        await tree.close();
+
+        await tree.open();
+        const {lastMeta, indexMeta} = tree.store;
+        assert.strictEqual(rootCache.size, initialRootCount);
+
+        const checkTreeRoots = [];
+        for (const hash of rootHashes.reverse()) {
+          const snap = tree.snapshot(hash);
+
+          try {
+            const root = await snap.getRoot();
+            checkTreeRoots.push(root);
+          } catch (e) {
+            checkTreeRoots.push(null);
+          }
+        }
+
+        for (let i = 0; i < initialRootCount; i++)
+          assert.notStrictEqual(checkTreeRoots[i], null);
+
+        for (let i = initialRootCount + 1; i < checkTreeRoots.length; i++)
+          assert.strictEqual(checkTreeRoots[i], null);
+
+        // neither lastMeta nor indexMeta should change.
+        assert.strictEqual(lastMeta, tree.store.lastMeta);
+        assert.strictEqual(indexMeta, tree.store.indexMeta);
+
+        await tree.close();
+      });
+
+      it('should only lookup initial cached roots (not cacheOnly)', async () => {
+        const initCacheSize = 2;
+        const initialRootCount = initCacheSize + 1;
+
+        const opts = {
+          ...options,
+          initCacheSize,
+          cacheOnly: false
+        };
+
+        const tree = new Tree(opts);
+        const {rootCache} = tree.store;
+
+        let rootHashes = [];
+
+        // prepare tree
+        {
+          await tree.open();
+          const {lastMeta} = tree.store;
+          const roots = await populateTree(tree, 10, 2);
+          assert.strictEqual(rootCache.size, 10);
+          assert(mapHasSet(rootCache, roots));
+
+          rootHashes = [...rootCache.values()].map(n => n.hash(tree.hash));
+
+          // lastMeta should have moved on.
+          assert.notStrictEqual(lastMeta, tree.store.lastMeta);
+          await tree.close();
+        }
+
+        // test
+        await tree.open();
+        const {lastMeta, indexMeta} = tree.store;
+
+        assert.strictEqual(rootCache.size, initialRootCount);
+
+        const checkTreeRoots = [];
+        for (const hash of rootHashes.reverse()) {
+          const snap = tree.snapshot(hash);
+
+          try {
+            const root = await snap.getRoot();
+            checkTreeRoots.push(root);
+          } catch (e) {
+            checkTreeRoots.push(null);
+          }
+        }
+
+        for (let i = 0; i < checkTreeRoots.length; i++)
+          assert.notStrictEqual(checkTreeRoots[i], null);
+
+        assert.strictEqual(lastMeta, tree.store.lastMeta);
+        assert.notStrictEqual(indexMeta, tree.store.indexMeta);
+
+        await tree.close();
+      });
+    });
+  }
+});

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -102,6 +102,9 @@ describe('Store', function() {
         assert(mapHasSet(rootCache, roots));
 
         await tree.close();
+
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
       });
 
       it('should not recover hashes when initCacheSize is 0', async () => {
@@ -123,12 +126,15 @@ describe('Store', function() {
         assert(mapHasSet(rootCache, roots));
         await tree.close();
 
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
+
         // test
         await tree.open();
         // last meta root itself is getting cached.
         assert.strictEqual(rootCache.size, 1);
 
-        const {lastMeta, indexMeta} = tree.store;
+        const {lastMeta, lastCachedMeta} = tree.store;
 
         // cache one more thing.
         roots = new Set([
@@ -140,8 +146,8 @@ describe('Store', function() {
         assert.strictEqual(rootCache.size, roots.size);
         assert(mapHasSet(rootCache, roots));
 
-        // indexMeta does not go forward
-        assert.strictEqual(indexMeta, tree.store.indexMeta);
+        // lastCachedMeta does not go forward
+        assert.strictEqual(lastCachedMeta, tree.store.lastCachedMeta);
         assert.notStrictEqual(lastMeta, tree.store.lastMeta);
 
         await tree.close();
@@ -161,6 +167,9 @@ describe('Store', function() {
         assert.strictEqual(rootCache.size, 10);
         assert(mapHasSet(rootCache, roots));
         await tree.close();
+
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
 
         await tree.open();
         assert.strictEqual(rootCache.size, 10);
@@ -187,14 +196,17 @@ describe('Store', function() {
         assert(mapHasSet(rootCache, roots));
         await tree.close();
 
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
+
         await tree.open();
         assert.strictEqual(rootCache.size, initialRootCount);
         const lastThree = new Set([...roots].slice(-initialRootCount));
         assert(mapHasSet(rootCache, lastThree));
 
-        // make sure indexMeta is correctly set to the last indexed root.
+        // make sure lastCachedMeta is correctly set to the last indexed root.
         const last = [...rootCache.values()][initialRootCount - 1].hash();
-        const checkRoot = await tree.store.readRoot(tree.store.indexMeta.rootPtr);
+        const checkRoot = await tree.store.readRoot(tree.store.lastCachedMeta.rootPtr);
         assert.bufferEqual(last, checkRoot.hash());
 
         await tree.close();
@@ -219,8 +231,11 @@ describe('Store', function() {
         rootHashes = [...rootCache.values()].map(n => n.hash(tree.hash));
         await tree.close();
 
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
+
         await tree.open();
-        const {lastMeta, indexMeta} = tree.store;
+        const {lastMeta, lastCachedMeta} = tree.store;
         assert.strictEqual(rootCache.size, 1);
 
         const checkTreeRoots = [];
@@ -239,9 +254,9 @@ describe('Store', function() {
         for (let i = 1; i < checkTreeRoots.length; i++)
           assert.strictEqual(checkTreeRoots[i], null);
 
-        // neither lastMeta nor indexMeta should change.
+        // neither lastMeta nor lastCachedMeta should change.
         assert.strictEqual(lastMeta, tree.store.lastMeta);
-        assert.strictEqual(indexMeta, tree.store.indexMeta);
+        assert.strictEqual(lastCachedMeta, tree.store.lastCachedMeta);
 
         await tree.close();
       });
@@ -269,8 +284,11 @@ describe('Store', function() {
         rootHashes = [...rootCache.values()].map(n => n.hash(tree.hash));
         await tree.close();
 
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
+
         await tree.open();
-        const {lastMeta, indexMeta} = tree.store;
+        const {lastMeta, lastCachedMeta} = tree.store;
         assert.strictEqual(rootCache.size, initialRootCount);
 
         const checkTreeRoots = [];
@@ -291,9 +309,9 @@ describe('Store', function() {
         for (let i = initialRootCount + 1; i < checkTreeRoots.length; i++)
           assert.strictEqual(checkTreeRoots[i], null);
 
-        // neither lastMeta nor indexMeta should change.
+        // neither lastMeta nor lastCachedMeta should change.
         assert.strictEqual(lastMeta, tree.store.lastMeta);
-        assert.strictEqual(indexMeta, tree.store.indexMeta);
+        assert.strictEqual(lastCachedMeta, tree.store.lastCachedMeta);
 
         await tree.close();
       });
@@ -328,9 +346,12 @@ describe('Store', function() {
           await tree.close();
         }
 
+        // make sure root is cleared on close.
+        assert.strictEqual(rootCache.size, 0);
+
         // test
         await tree.open();
-        const {lastMeta, indexMeta} = tree.store;
+        const {lastMeta, lastCachedMeta} = tree.store;
 
         assert.strictEqual(rootCache.size, initialRootCount);
 
@@ -350,7 +371,7 @@ describe('Store', function() {
           assert.notStrictEqual(checkTreeRoots[i], null);
 
         assert.strictEqual(lastMeta, tree.store.lastMeta);
-        assert.notStrictEqual(indexMeta, tree.store.indexMeta);
+        assert.notStrictEqual(lastCachedMeta, tree.store.lastCachedMeta);
 
         await tree.close();
       });

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -41,7 +41,10 @@ describe('Urkel radix', function() {
   this.timeout(5000);
 
   it('should test tree', async () => {
-    const tree = new Tree(sha256, 160);
+    const tree = new Tree({
+      hash: sha256,
+      bits: 160
+    });
 
     await tree.open();
 
@@ -204,7 +207,10 @@ describe('Urkel radix', function() {
 
   it('should test max value size', async () => {
     const MAX_VALUE = 0x3ff;
-    const tree = new Tree(sha256, 160);
+    const tree = new Tree({
+      hash: sha256,
+      bits: 160
+    });
 
     await tree.open();
 
@@ -246,7 +252,11 @@ describe('Urkel radix', function() {
   });
 
   it('should pummel tree', async () => {
-    const tree = new Tree(sha256, 160);
+    const tree = new Tree({
+      hash: sha256,
+      bits: 160
+    });
+
     const items = [];
     const set = new Set();
 
@@ -435,10 +445,15 @@ describe('Urkel radix', function() {
       items.push([key, value]);
     }
 
-    const tree1 = new Tree(sha256, 160);
+    const opts = {
+      hash: sha256,
+      bits: 160
+    };
+
+    const tree1 = new Tree(opts);
     await tree1.open();
 
-    const tree2 = new Tree(sha256, 160);
+    const tree2 = new Tree(opts);
     await tree2.open();
 
     let root = null;


### PR DESCRIPTION
  This PR addresses issue #20. It is based on #19.
  
  This is also breaking change. Instead of 3 parameters, we instead pass `Object` in the properties. It is part of `v0.8/v1.0` milestone. This PR introduces two additional options for configurations:
  - `cacheOnly (bool)` - Whether to go to the disk or not for looking up roots.
  - `initCacheSize` - How many root hashes to recover from the disk on open.
    This will go to the disk regardless of `cacheOnly` option.

  `cacheOnly` addresses predictibility of the lookup speeds. If something is not found in cache, it will throw `MissingNodeError`. `initCacheSize` can be set to `0` in order to forbid it from restoring cache. For relatively small trees (or until opening time becomes noticable) this can be set to `-1` which will cache every root from the beginning.

  Current defaults are backwards compatible, behaves as before:
```
{
  initCacheSize: 0,
  cacheOnly: false
}
```
  It wont recover anything on open and will go to disk whenever something is not in cache (or missing and will reindex cache during that).

  I believe the best combination you get when you never lookup tree and cache every hash on open `{ initCacheSize: -1, cacheOnly: true }`. This even though slows down on open, during run never has to go to the history making node lookup speeds predictable. Well, `initCacheSize: -1` makes `cacheOnly` obsolete because everything get indexed on open anyway so it wont go to the disk even if something does not exist as `indexMeta` will be set to first ever meta.

### Minor Fix
  This also has minor fix for the `lastMeta` issue mentioned in #20. This introduces `indexMeta` that is separate, is recovered during open set to the most recent `meta` and it can only go backwards (no need to go forward with `lastMeta` as new roots are cached as they are added).

  `indexMeta` is used for `initCacheSize` as well, so if we need to lookup something that was not recovered during open (depends on `initCacheSize`), it will just continue where it stopped.