### PR TITLE
Pad only when necessary.

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -601,13 +601,13 @@ class Store {
     state.rootPtr = root.ptr;
     state.rootNode = root.toHash(this.hash);
 
-    let padding = 0;
+    if (this.buffer.pos % META_SIZE) {
+      const padding = META_SIZE - (this.buffer.pos % META_SIZE);
+      this.buffer.expand(padding);
+      this.buffer.pad(padding);
+    }
 
-    if (this.buffer.pos % META_SIZE)
-      padding = META_SIZE - (this.buffer.pos % META_SIZE);
-
-    this.buffer.expand(padding + META_SIZE);
-    this.buffer.pad(padding);
+    this.buffer.expand(META_SIZE);
 
     const off = state.write(
       this.buffer.data,

--- a/lib/store.js
+++ b/lib/store.js
@@ -601,7 +601,10 @@ class Store {
     state.rootPtr = root.ptr;
     state.rootNode = root.toHash(this.hash);
 
-    const padding = META_SIZE - (this.buffer.pos % META_SIZE);
+    let padding = 0;
+
+    if (this.buffer.pos % META_SIZE)
+      padding = META_SIZE - (this.buffer.pos % META_SIZE);
 
     this.buffer.expand(padding + META_SIZE);
     this.buffer.pad(padding);

--- a/test/store-test.js
+++ b/test/store-test.js
@@ -4,7 +4,7 @@ const assert = require('bsert');
 const {tmpdir} = require('os');
 const path = require('path');
 const fs = require('bfile');
-const {sha256} = require('./util/util');
+const {BLAKE2b} = require('bcrypto');
 const {Tree} = require('../lib/urkel');
 const os = require('os');
 
@@ -58,8 +58,8 @@ function mapHasSet(map, set) {
 
 describe('Store', function() {
   const treeOptions = {
-    hash: sha256,
-    bits: 160
+    hash: BLAKE2b,
+    bits: 256
   };
 
   for (const memory of [true, false]) {


### PR DESCRIPTION
The store will add extra META_SIZE padding even when there's no need for the pad (e.g. empty commit).
Also because we already have bcrypto for bench as devDependency, we can use it for the tests as well.